### PR TITLE
clean multiline label code

### DIFF
--- a/gratex.js
+++ b/gratex.js
@@ -203,26 +203,7 @@ function getLabel(calculator) {
             const exp = calculator.getExpressions().find(exp => exp.latex);
             return exp ? exp.latex : '?????????';
         case 'custom':
-            const exps = calculatorLabel
-                .getExpressions()
-                .flatMap(exp => (exp.latex ? [`\\textcolor{black}{${exp.latex}}`] : ''));
-            const spacing = Math.max(Math.ceil(Math.log2(exps.length)) - 1, 1);
-            return exps.length ? `\\textcolor{transparent}{${groupLines(exps, spacing)}}` : '?????????';
+            const exps = calculatorLabel.getExpressions().map(exp => `\\class{multiline-item}{${exp.latex ?? ''}}`);
+            return exps.length ? `\\class{multiline-list}{${exps.join('')}}` : '?????????';
     }
-}
-
-// https://github.com/FuriousChocolate/LaTeXmos/blob/main/website/convert.js
-function groupLines(lines, n) {
-    const newLines = [];
-    for (let i = 0; i < lines.length - 1; i += 2) {
-        newLines.push(`\\binom{${lines[i]}}{${nestOverline(lines[i + 1], n * 3)}}`);
-    }
-    if (lines.length & 1) {
-        newLines.push(`\\left(${lines[lines.length - 1]}\\right)`);
-    }
-    return newLines.length === 1 ? newLines[0] : groupLines(newLines, n - 1);
-}
-
-function nestOverline(line, n) {
-    return n ? nestOverline(`\\overline{${line}}`, --n) : line;
 }

--- a/style.css
+++ b/style.css
@@ -292,3 +292,15 @@ textarea {
 .footer {
   margin-bottom: 0;
 }
+
+.multiline-list {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+
+.multiline-item {
+  display: block;
+}


### PR DESCRIPTION
uses mathquill's \class{} command to format the label using css, instead of relying on funky \binom{}{} stuff.
that means it also gives more control over the styling: for example, it's easier to change the gap between the expressions.
the output should look more or less identical.