### PR TITLE
ラベル表示の対応

### DIFF
--- a/gratex.js
+++ b/gratex.js
@@ -203,10 +203,7 @@ function getLabel(calculator) {
             const exp = calculator.getExpressions().find(exp => exp.latex);
             return exp ? exp.latex : '?????????';
         case 'custom':
-            const exps = calculatorLabel
-                .getExpressions()
-                .flatMap(exp => (exp.latex ? [`\\textcolor{black}{${exp.latex}}`] : ''));
-            const spacing = Math.max(Math.ceil(Math.log2(exps.length)) - 1, 1);
-            return exps.length ? `\\textcolor{transparent}{${groupLines(exps, spacing)}}` : '?????????';
+            const exps = calculatorLabel.getExpressions().map(exp => `\\class{multiline-item}{${exp.latex ?? ''}}`);
+            return exps.length ? `\\class{multiline-list}{${exps.join('')}}` : '?????????';
     }
 }

--- a/gratex.js
+++ b/gratex.js
@@ -18,7 +18,6 @@ const calculatorLabel = Desmos.GraphingCalculator(calcLabelElt, {
     actions: false,
     branding: false
 });
-
 const calculatorLabelScreenshot = Desmos.GraphingCalculator(document.createElement('div'), {
     showGrid: false,
     showXAxis: false,
@@ -210,20 +209,4 @@ function getLabel(calculator) {
             const spacing = Math.max(Math.ceil(Math.log2(exps.length)) - 1, 1);
             return exps.length ? `\\textcolor{transparent}{${groupLines(exps, spacing)}}` : '?????????';
     }
-}
-
-// https://github.com/FuriousChocolate/LaTeXmos/blob/main/website/convert.js
-function groupLines(lines, n) {
-    const newLines = [];
-    for (let i = 0; i < lines.length - 1; i += 2) {
-        newLines.push(`\\binom{${lines[i]}}{${nestOverline(lines[i + 1], n * 3)}}`);
-    }
-    if (lines.length & 1) {
-        newLines.push(`\\left(${lines[lines.length - 1]}\\right)`);
-    }
-    return newLines.length === 1 ? newLines[0] : groupLines(newLines, n - 1);
-}
-
-function nestOverline(line, n) {
-    return n ? nestOverline(`\\overline{${line}}`, --n) : line;
 }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       gtag('js', new Date());
       gtag('config', 'G-1JR9SZ33HJ');
     </script>
-    <script src="https://www.desmos.com/api/v1.9/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
+    <script src="https://www.desmos.com/api/v1.10/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
     <title>Graph + LaTeX Generator</title>
   </head>
   <body>


### PR DESCRIPTION
v1.10に更新する際に、ラベルが表示されないバグが見受けられ修正を行った。

\class{multiline-list}, \class{multiline-item} が利用できないため、https://github.com/TETH-Main/GraTeX/pull/19/files 版のコードを再利用しています。