### PR TITLE
Change how to enter label size

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,23 @@
     </div>
     <div id="calculator"></div>
     <div id="calculator-3d"></div>
+    <div class="card">
+      <div class="card-body">
+      <div class="form-row">
+        <div class="col stretch">
+          <textarea class="form-control" id="desmos-hash" name="test" cols="10" rows="1"
+            placeholder="Fill in a Desmos Graphing Caluculator URL or hash here…" autocomplete="off" autocorrect="off"
+            autocapitalize="off" spellcheck="false"></textarea>
+        </div>
+        <div class="col">
+          <button class="btn btn-import" id="import-button" type="button">
+            <span>Import</span>
+          </button>
+        </div>
+      </div>
+      </div>
+    </div>
+
     <div class="card" id="form-container">
       <div class="card-body">
         <!-- タブ切り替えUI -->
@@ -90,18 +107,6 @@
         </div>
         <!-- Layoutタブ内容 -->
         <div id="layout-panel">
-          <div class="form-row">
-            <div class="col stretch">
-              <textarea class="form-control" id="desmos-hash" name="test" cols="10" rows="1"
-                placeholder="Fill in a Desmos Graphing Caluculator URL or hash here…" autocomplete="off" autocorrect="off"
-                autocapitalize="off" spellcheck="false"></textarea>
-            </div>
-            <div class="col">
-              <button class="btn btn-import" id="import-button" type="button">
-                <span>Import</span>
-              </button>
-            </div>
-          </div>
           <div class="form-row" id="label-radio">
             <div class="col stretch">
               <div class="form-group">
@@ -119,41 +124,27 @@
                 </div>
               </div>
             </div>
-            <div class="col">
-              <div id="calculator-label"></div>
-            </div>
           </div>
+          <div class="col">
+            <div id="calculator-label"></div>
+          </div>
+
           <div class="form-row">
             <div class="col stretch">
               <div class="form-group">
-                <label>Label Font</label>
-                <form name="labelFont">
-                  <select name="labelFont" class="form-control">
-                    <option value="" selected>Default</option>
-                    <option value="mathrm">Roman</option>
-                    <option value="mathit">Italic</option>
-                    <option value="mathbf">Bold</option>
-                    <option value="mathsf">Sans-serif</option>
-                    <option value="mathtt">Monospace</option>
-                  </select>
-                </form>
-              </div>
-            </div>
-            <div class="col stretch">
-              <div class="form-group">
                 <label>Label Size</label>
-                <form name="labelSize">
-                  <select name="labelSize" class="form-control">
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="2.5">2.5</option>
-                    <option value="3">3</option>
-                    <option value="4" selected>4</option>
-                    <option value="6">6</option>
-                    <option value="8">8</option>
-                    <option value="auto">Auto</option>
-                  </select>
-                </form>
+                <div class="label-size-container">
+                  <form name="labelSize" class="label-size-slider">
+                    <input type="range" name="labelSize" class="form-control" min="0.1" max="10" step="0.1" value="4">
+                    <output class="label-size-value">4</output>
+                  </form>
+                  <div class="label-size-auto">
+                    <label>
+                      <input type="checkbox" name="labelSizeAuto" id="labelSizeAuto">
+                      Auto
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -162,7 +153,7 @@
             <button id="advanced-options" class="advanced-options-button" aria-expanded="false">
               Advanced Options
               <svg class="dropdown-arrow" width="12" height="12" viewBox="0 0 12 12">
-                <path d="M2 8l4 -4 4 4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                <path d="M8 10l-4 -4 4 -4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
               </svg>
             </button>
             <div id="advanced-menu" class="advanced-menu" style="display: none;">
@@ -203,6 +194,23 @@
                   </span>
                 </label>
               </div>
+
+              <div class="col stretch">
+                <div class="form-group">
+                  <label>Label Font</label>
+                  <form name="labelFont">
+                    <select name="labelFont" class="form-control">
+                      <option value="" selected>x² + y² = r² (Default)</option>
+                      <option value="mathrm">x² + y² = r² (Roman)</option>
+                      <option value="mathit">x² + y² = r² (Italic)</option>
+                      <option value="mathbf">x² + y² = r² (Bold)</option>
+                      <option value="mathsf">x² + y² = r² (Sans-serif)</option>
+                      <option value="mathtt">x² + y² = r² (Monospace)</option>
+                    </select>
+                  </form>
+                </div>
+              </div>
+
               <div class="form-row">
                 <div class="col">
                   <label><input type="color" value="#FFFFFF" id="color" /> Background Color</label>
@@ -231,9 +239,11 @@
               <!-- カスタムサイズ入力フィールド -->
               <div class="form-group" id="custom-dimension-inputs" style="display: none;">
                 <div class="custom-dimension-row">
-                  <input type="number" id="custom-width" class="form-control custom-dimension-input" placeholder="Width" min="100" max="10000" step="1">
+                  <input type="number" id="custom-width" class="form-control custom-dimension-input" placeholder="Width"
+                    min="100" max="10000" step="1">
                   <span class="custom-dimension-separator">×</span>
-                  <input type="number" id="custom-height" class="form-control custom-dimension-input" placeholder="Height" min="100" max="10000" step="1">
+                  <input type="number" id="custom-height" class="form-control custom-dimension-input"
+                    placeholder="Height" min="100" max="10000" step="1">
                 </div>
               </div>
             </div>
@@ -253,13 +263,14 @@
                 Add Variable Label
               </label>
             </div>
-          </div>          <div class="form-row" style="align-items: center;">
+          </div>
+          <div class="form-row" style="align-items: center;">
             <div class="col stretch">
               <div class="form-group">
                 <div id="movie-start" class="form-control mathquill-input"></div>
               </div>
             </div>
-            <div style="align-self: center; padding: 0 8px;">
+            <div style="align-self: center;">
               <span class="movie-leq">&leq;</span>
             </div>
             <div class="col stretch">
@@ -269,7 +280,7 @@
                 </select>
               </div>
             </div>
-            <div style="align-self: center; padding: 0 8px;">
+            <div style="align-self: center;">
               <span class="movie-leq">&leq;</span>
             </div>
             <div class="col stretch">
@@ -288,14 +299,17 @@
             <div class="col stretch">
               <div class="form-group">
                 <label for="movie-framerate">Frame Rate (fps)</label>
-                <input type="number" id="movie-framerate" class="form-control" placeholder="e.g. 30" min="1" max="60" value="30" />
+                <input type="number" id="movie-framerate" class="form-control" placeholder="e.g. 30" min="1" max="60"
+                  value="30" />
               </div>
             </div>
             <div class="col" style="max-width: 220px;">
-              <button class="btn btn-primary btn-generate" id="generate-movie-button" type="button" style="width: 100%;">
+              <button class="btn btn-primary btn-generate" id="generate-movie-button" type="button"
+                style="width: 100%;">
                 <span>Generate Movie</span>
               </button>
-              <button class="btn btn-cancel btn-generate" id="cancel-movie-button" type="button" style="width: 100%; display: none;">
+              <button class="btn btn-cancel btn-generate" id="cancel-movie-button" type="button"
+                style="width: 100%; display: none;">
                 <span>Cancel Generation</span>
               </button>
             </div>

--- a/script/GraTeXUtils.js
+++ b/script/GraTeXUtils.js
@@ -15,6 +15,7 @@ export class GraTeXUtils {
      */
     calculateAutoLabelSize() {
         try {
+            console.log('Calculating auto label size...');
             // 現在のlabelタイプを取得
             const currentLabelValue = this.app.getCurrentLabelValue();
             
@@ -59,6 +60,8 @@ export class GraTeXUtils {
 
                 console.log(`Desmos top expression size (${is2D ? '2D' : '3D'}): ${totalWidth}px × ${totalHeight}px`);
             } else if (currentLabelValue === 'custom') {
+                this.app.calculatorLabel.focusFirstExpression(); //一番上の指揮に移動
+                
                 // custom labelの場合：calculator-labelコンテナ内のDOM要素から横幅・縦幅を取得
                 const parentElement = document.querySelector('#calculator-label .dcg-template-expressioneach');
                 if (!parentElement) {
@@ -112,12 +115,13 @@ export class GraTeXUtils {
             
             // 横幅と縦幅の両方を考慮してサイズを調整
             const targetWidth = this.width * 0.8;
-            const targetHeight = (this.height - this.graphSize) * 0.8;
+            const targetHeight = (this.height - this.graphSize) * 0.8 - this.graphMargin;
             const autoSizeByWidth = 4 * (targetWidth / ExpectedWidth);
             const autoSizeByHeight = 4 * (targetHeight / ExpectedHeight);
             
             // 横幅と縦幅の制約のうち、より厳しい方（小さい方）を採用
             const autoSize = Math.min(autoSizeByWidth, autoSizeByHeight);
+            console.log(totalHeight, totalWidth, ExpectedHeight, ExpectedWidth);
             
             console.log(`Auto size calculation: width=${autoSizeByWidth.toFixed(2)}, height=${autoSizeByHeight.toFixed(2)}, final=${autoSize.toFixed(2)}`);
             
@@ -238,6 +242,7 @@ export class GraTeXUtils {
 
             const label = this.app.getLabel(calculator);
             const ratio = (Math.min(this.width, this.height) >= 360) + 1;
+            console.log(label);
             
             // CalculatorLabelScreenshotを設定・実行する共通処理
             const setupCalculatorLabel = (labelSize) => {
@@ -271,10 +276,10 @@ export class GraTeXUtils {
 
             // AutoサイズかどうかをチェックしてlabelSizeを決定
             let effectiveLabelSize = this.app.labelSize.value;
-            if (effectiveLabelSize === 'auto') {
+
+            if (this.app.labelSize.disabled) { // labelSize = auto
                 // PNG生成時にDesmosのDOM要素からautoサイズを計算
-                effectiveLabelSize = this.calculateAutoLabelSize();
-                setupCalculatorLabel(effectiveLabelSize);
+                setupCalculatorLabel(this.calculateAutoLabelSize());
             } else {
                 effectiveLabelSize = parseFloat(effectiveLabelSize);
                 setupCalculatorLabel(effectiveLabelSize);

--- a/style.css
+++ b/style.css
@@ -179,7 +179,7 @@ a.disabled {
 }
 
 #calculator-label {
-  width: 400px;
+  /* width: 400px; */
   height: 300px;
   margin-bottom: 1rem;
 }
@@ -239,6 +239,40 @@ a.disabled {
   margin-bottom: 10px;
 }
 
+.label-size-container {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.label-size-slider {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.label-size-slider input[type="range"] {
+  flex: 1;
+  margin: 0;
+  padding: 0;
+}
+
+.label-size-value {
+  min-width: 2.5em;
+  text-align: right;
+}
+
+.label-size-auto {
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+}
+
+.label-size-auto input[type="checkbox"] {
+  margin-right: 4px;
+}
+
 .form-control {
   display: block;
   width: 100%;
@@ -253,6 +287,40 @@ a.disabled {
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+/* フォントプレビュー用スタイル */
+select[name="labelFont"] option {
+  padding: 8px 12px;
+  min-height: 1.5em;
+  font-size: 1.1rem;
+}
+
+select[name="labelFont"] option[value=""] {
+  font-family: 'Times New Roman', serif;
+  font-style: italic;
+}
+
+select[name="labelFont"] option[value="mathrm"] {
+  font-family: 'Times New Roman', serif;
+}
+
+select[name="labelFont"] option[value="mathit"] {
+  font-family: 'Times New Roman', serif;
+  font-style: italic;
+}
+
+select[name="labelFont"] option[value="mathbf"] {
+  font-family: 'Times New Roman', serif;
+  font-weight: bold;
+}
+
+select[name="labelFont"] option[value="mathsf"] {
+  font-family: Arial, sans-serif;
+}
+
+select[name="labelFont"] option[value="mathtt"] {
+  font-family: 'Courier New', monospace;
 }
 
 .mathquill-input {
@@ -455,7 +523,7 @@ textarea {
 }
 
 .advanced-options-button[aria-expanded="true"] .dropdown-arrow {
-  transform: rotate(180deg);
+  transform: rotate(-90deg);
 }
 
 .advanced-menu {
@@ -538,6 +606,10 @@ textarea {
 
 #movie-panel .form-row[style*="justify-content: flex-end;"] {
   justify-content: flex-end;
+}
+
+#movie-panel .form-row {
+  gap: 5px;
 }
 
 .btn-generate {


### PR DESCRIPTION
データ取得: fetch メソッドを再導入し、新旧データに対応する分岐を追加
凡例: ラベルの凡例をより分かりやすく修正
レイアウト: カスタムラベル入力欄の位置を調整
スライダー: ラベルサイズをスライダーで変更可能に
バグ修正: 自動サイズ調整機能の縦幅測定の不具合を修正
整理: ラベルフォント設定を「詳細オプション」に移動

Data Import: Reverted to fetch method with conditional logic for new and old data.
Legends: Improved clarity of label legends.
Layout: Adjusted position of the custom label input field.
Slider: Changed label size control to a slider.
Bug Fix: Fixed vertical measurement issue in auto-size feature.
UI Cleanup: Moved label font settings to "Advanced Options."